### PR TITLE
fix quicksort.lua

### DIFF
--- a/lua/quicksort.lua
+++ b/lua/quicksort.lua
@@ -1,31 +1,22 @@
 
-function partition(array, left, right, pivotIndex)
-	local pivotValue = array[pivotIndex]
-	array[pivotIndex], array[right] = array[right], array[pivotIndex]
-	
-	local storeIndex = left
-	
-	for i =  left, right-1 do
-    	if array[i] <= pivotValue then
-	        array[i], array[storeIndex] = array[storeIndex], array[i]
-	        storeIndex = storeIndex + 1
+local function quicksort(t, left, right)
+	if right < left then return end
+	local pivot = left
+	for i = left + 1, right do
+		if t[i] <= t[pivot] then
+			if i == pivot + 1 then
+			  t[pivot],t[pivot+1] = t[pivot+1],t[pivot]
+			else
+			  t[pivot],t[pivot+1],t[i] = t[i],t[pivot],t[pivot+1]
+			end
+			pivot = pivot + 1
 		end
-		array[storeIndex], array[right] = array[right], array[storeIndex]
 	end
-	
-   return storeIndex
+	quicksort(t, left, pivot - 1)
+	quicksort(t, pivot + 1, right)
 end
 
-function quicksort(array, left, right)
-	if right > left then
-	    local pivotNewIndex = partition(array, left, right, left)
-	    quicksort(array, left, pivotNewIndex - 1)
-	    quicksort(array, pivotNewIndex + 1, right)
-	end
-end
-
-
-array = { 1, 5, 2, 17, 11, 3, 1, 22, 2, 37 }
+local array = { 1, 5, 2, 17, 11, 3, 1, 22, 2, 37 }
 
 quicksort(array, 1, #array)
 


### PR DESCRIPTION
Hello, I realize that this repo is 11 years old, but it is still the first result I get when I google for "Lua quicksort".

Unfortunately its current implementation does not work correctly:
```
$luajit lua/quicksort.lua
1
1
2
2
3
5
11
17
37
22
```

I have based this fix on [Rosetta stone's Quicksort in-place implementation](https://rosettacode.org/wiki/Sorting_algorithms/Quicksort#in-place). As a result I removed the `partition` helper function and had to change the variable names a little bit in order to make the multiple assignments less wide (which is objective) and more readable (this bit is subjective).

With the fix in place, quicksort.lua now properly sorts the array:
```
$luajit lua/quicksort.lua
1
1
2
2
3
5
11
17
22
37
```